### PR TITLE
Simple fix to stop fetchpage choking on latin-1 encoded pages

### DIFF
--- a/plugin/addon.xml
+++ b/plugin/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="script.module.parsedom.beta" name="Parsedom Beta for xbmc plugins" provider-name="TheCollective" version="1.5.1">
+<addon id="script.module.parsedom.beta" name="Parsedom Beta for xbmc plugins" provider-name="TheCollective" version="1.5.2">
   <requires>
     <import addon="xbmc.python" version="2.0" />
   </requires>

--- a/plugin/lib/CommonFunctions.py
+++ b/plugin/lib/CommonFunctions.py
@@ -440,7 +440,13 @@ def fetchPage(params={}):
             inputdata = con.read()
             #data_type = chardet.detect(inputdata)
             #inputdata = inputdata.decode(data_type["encoding"])
-            ret_obj["content"] = inputdata.decode("utf-8")
+            try:
+                ret_obj["content"] = inputdata.decode("utf-8")                    
+            except:
+                try:
+                    ret_obj["content"] = inputdata.decode("latin-1")                    
+                except:
+                    raise    
 
         con.close()
 


### PR DESCRIPTION
Basic fix to stop fetchpage choking on latin-1 encoded pages.  I can see some commented out attempt to deal with this, but this is simple and it works, has been in use for 6+ months with my OzWeather addon.
