### PR TITLE
getXBMCVersion: handle pre-release versions

### DIFF
--- a/plugin/lib/CommonFunctions.py
+++ b/plugin/lib/CommonFunctions.py
@@ -100,7 +100,8 @@ def getXBMCVersion():
     for key in ["-", " "]:
         if version.find(key) -1:
             version = version[:version.find(key)]
-    version = float(version)
+    # trim from first non-float character to end of string. e.g. 13.2-ALPHA1 to 13.2
+    version = float(re.sub("[^0-9.].*", "", version))
     log(repr(version))
     return version
 


### PR DESCRIPTION
Versions like 13.2ALPHA1 cause the code to explode currently. This commit will truncate the above to 13.2.
